### PR TITLE
fix: remove che debug flag (no use for JPDA debugger in a bosh release)

### DIFF
--- a/jobs/che/templates/bin/ctl
+++ b/jobs/che/templates/bin/ctl
@@ -66,7 +66,7 @@ case $1 in
     # store pid in $PIDFILE
     echo $$ > $PIDFILE
 
-    exec chpst -u vcap:vcap /var/vcap/packages/che/che/bin/che.sh --debug -r:${DOCKER_HOST_IP} \
+    exec chpst -u vcap:vcap /var/vcap/packages/che/che/bin/che.sh -r:${DOCKER_HOST_IP} \
          >>$LOG_DIR/$JOB_NAME.stdout.log \
          2>>$LOG_DIR/$JOB_NAME.stderr.log
 


### PR DESCRIPTION
remove debug flag for issue https://github.com/cloudfoundry-community/eclipse-che-boshrelease/issues/1
